### PR TITLE
Heads by texture ID

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,12 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.spigotmc</groupId>
+			<artifactId>spigot</artifactId>
+			<version>1.10.2-R0.1-SNAPSHOT</version>
+			<scope><provided></provided></scope>
+		</dependency>
+		<dependency>
+			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
 			<version>1.10-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot</artifactId>
 			<version>1.10.2-R0.1-SNAPSHOT</version>
-			<scope><provided></provided></scope>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.spigotmc</groupId>

--- a/src/main/java/org/black_ixx/bossshop/managers/ItemStackCreator.java
+++ b/src/main/java/org/black_ixx/bossshop/managers/ItemStackCreator.java
@@ -1,9 +1,14 @@
 package org.black_ixx.bossshop.managers;
 
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
+import java.util.UUID;
 
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.properties.Property;
 import org.black_ixx.bossshop.managers.external.GuiShopManagerManager;
 import org.bukkit.Bukkit;
 
@@ -377,6 +382,35 @@ public class ItemStackCreator {
 				i=gi; 
 				continue;
 			}
+
+			if (s.equalsIgnoreCase("headtexture")) {
+				if (i.getType() == Material.SKULL_ITEM) {
+					SkullMeta itemMeta = (SkullMeta) i.getItemMeta();
+
+					String url = "http://textures.minecraft.net/texture/" + a;
+
+					GameProfile profile = new GameProfile(UUID.randomUUID(), null);
+					byte[] encodedData = Base64.getEncoder().encode(String.format("{textures:{SKIN:{url:\"%s\"}}}", url).getBytes());
+					profile.getProperties().put("textures", new Property("textures", new String(encodedData)));
+					Field profileField = null;
+					try {
+						profileField = itemMeta.getClass().getDeclaredField("profile");
+					} catch (NoSuchFieldException | SecurityException e) {
+						e.printStackTrace();
+					}
+					assert profileField != null;
+					profileField.setAccessible(true);
+					try {
+						profileField.set(itemMeta, profile);
+					} catch (IllegalArgumentException | IllegalAccessException e) {
+						e.printStackTrace();
+					}
+					i.setItemMeta(itemMeta);
+				} else {
+					ClassManager.manager.getBugFinder().severe("Mistake in Config: cannot set head texture for non skull item");
+				}
+			}
+
 
 
 		}


### PR DESCRIPTION
Allow users to add heads by texture ID, i.e any head from http://textures.minecraft.net/texture/
